### PR TITLE
Added getName method to ModuleInstaller.

### DIFF
--- a/src/Backend/Core/Installer/ModuleInstaller.php
+++ b/src/Backend/Core/Installer/ModuleInstaller.php
@@ -37,6 +37,13 @@ class ModuleInstaller
     private $db;
 
     /**
+     * The module name.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
      * The default extras that have to be added to every page.
      *
      * @var array
@@ -111,19 +118,20 @@ class ModuleInstaller
     }
 
     /**
-     * Inserts a new module
+     * Inserts a new module.
+	 * The getName method becomes available after using addModule and returns $name parameter.
      *
      * @param string $name The name of the module.
      */
     protected function addModule($name)
     {
-        $name = (string) $name;
+        $this->name = (string) $name;
 
         // module does not yet exists
-        if (!(bool) $this->getDB()->getVar('SELECT 1 FROM modules WHERE name = ? LIMIT 1', $name)) {
+        if (!(bool) $this->getDB()->getVar('SELECT 1 FROM modules WHERE name = ? LIMIT 1', $this->name)) {
             // build item
             $item = array(
-                'name' => $name,
+                'name' => $this->name,
                 'installed_on' => gmdate('Y-m-d H:i:s')
             );
 
@@ -131,7 +139,7 @@ class ModuleInstaller
             $this->getDB()->insert('modules', $item);
         } else {
             // activate and update description
-            $this->getDB()->update('modules', array('installed_on' => gmdate('Y-m-d H:i:s')), 'name = ?', $name);
+            $this->getDB()->update('modules', array('installed_on' => gmdate('Y-m-d H:i:s')), 'name = ?', $this->name);
         }
     }
 
@@ -213,6 +221,16 @@ class ModuleInstaller
     protected function getDB()
     {
         return $this->db;
+    }
+
+    /**
+     * Get the module name
+     *
+     * @return string
+     */
+    protected function getName()
+    {
+        return $this->name;
     }
 
     /**


### PR DESCRIPTION
The getName method in ModuleInstaller becomes available after calling addModule.

This particularly heplful for setting up the module. As an example instead of using :

$this->setActionRights(1, 'Providers', 'Index');

we would use

$this->setActionRights(1, $this->getName(), 'Index');

and have less chance to have typo errors
