### PR TITLE
Set edited_on to current date time when an faq feedback is processed.

### DIFF
--- a/src/Backend/Modules/Faq/Engine/Model.php
+++ b/src/Backend/Modules/Faq/Engine/Model.php
@@ -111,7 +111,7 @@ class Model
     {
         BackendModel::getContainer()->get('database')->update(
             'faq_feedback',
-            array('processed' => 'Y'),
+            array('processed' => 'Y', 'edited_on' => \SpoonDate::getDate('Y-m-d H:i:s')),
             'id = ?',
             (int) $itemId
         );


### PR DESCRIPTION
After an faq feedback has been processed its "edited_on" field is not updated. Now it is done correctly.
